### PR TITLE
Fix seeds weren't generated or displayed in top left corner of path

### DIFF
--- a/src/seeds.js
+++ b/src/seeds.js
@@ -148,6 +148,12 @@ class Seeds{
             let samples
             if(inside_path){
                 samples = this.samples_in_path(box)
+                // Convert from viewport to SVG-relative coordinates
+                const parentRect = this.shape.parent.getBoundingClientRect()
+                for (let j=0;j<samples.length;j++){
+                    samples[j].x -= parentRect.x;
+                    samples[j].y -= parentRect.y;
+                }
             }else{
                 samples = samples_in_rect(this.config.nb_samples,w,h)
             }
@@ -265,7 +271,9 @@ class Seeds{
                 this.shape.append_path()
                 for(let i=0;i<this.array.length;i++){
                     const s = this.array[i]
-                    if(geom.inside_id(s.x, s.y, this.shape.svg_path.id)){
+                    const parentRect = this.shape.parent.getBoundingClientRect()
+                    // Convert to viewport coordinates for hit testing
+                    if(geom.inside_id(s.x + parentRect.x, s.y + parentRect.y, this.shape.svg_path.id)){
                         svg.circle_p_id(group,s.x,s.y,`c_${s.id}`)
                     }
                 }

--- a/src/voronoi_diag.js
+++ b/src/voronoi_diag.js
@@ -380,12 +380,13 @@ class voronoi_diag{
             let group = html(params.svg,/*html*/`<g id="svg_g_bezier_cells" ${conditional_clip_path}/>`)
             if(cfg.use_filters){svg.filter_turb_disp(group,{id:"f_turb_disp",disp_scale:cfg.disp_scale,turb_freq:cfg.turb_freq})}
             this.shape.append_path()
+            const parentRect = this.shape.parent.getBoundingClientRect()
             for(let i=0;i<this.cells.length;i++){
                 const c = this.cells[i]
                 //here you can retract or detract small edges before either drawing technique
                 let draw_cell = true
                 if(this.shape.show_inside_path()){
-                    draw_cell = geom.inside_id(c.seed.x, c.seed.y,this.shape.svg_path.id)
+                    draw_cell = geom.inside_id(parentRect.x + c.seed.x, parentRect.y + c.seed.y,this.shape.svg_path.id)
                 }
                 if(draw_cell){
                     let d


### PR DESCRIPTION
Seeds were never generated or displayed in the top left side of a loaded path SVG, because there were mismatches between the viewport coordinates needed by `inside_id`'s call to `elementByPoint`, and the SVG-relative coordinates needed by the rest of the app. This meant that unless there was no padding at all on the webpage, coordinates got shifted.

Fixes #11

Before, with old code:

![Screen Shot 2022-08-08 at 5 47 45 PM](https://user-images.githubusercontent.com/1921411/183348157-cee0ba14-9593-49bf-86e7-f0331601a5e6.png)

After fix:

![Screen Shot 2022-08-08 at 5 47 14 PM](https://user-images.githubusercontent.com/1921411/183348173-f63c2b78-67fd-4e63-9b37-b4b7410b83ef.png)
